### PR TITLE
Fix ARM template properties to enable Bicep conversion

### DIFF
--- a/AutomationRules/SampleAutomationRule.json
+++ b/AutomationRules/SampleAutomationRule.json
@@ -8,7 +8,6 @@
     },
     "resources": [
         {
-            "id": "[concat(resourceId('Microsoft.OperationalInsights/workspaces/providers', parameters('workspace'), 'Microsoft.SecurityInsights'),'/automationRules/85f2eac9-43f1-480e-b8ad-473375c195c0')]",
             "name": "[concat(parameters('workspace'),'/Microsoft.SecurityInsights/85f2eac9-43f1-480e-b8ad-473375c195c0')]",
             "type": "Microsoft.OperationalInsights/workspaces/providers/automationRules",
             "kind": "Scheduled",

--- a/Parsers/Sample/ASimAuthenticationAWSCloudTrail.json
+++ b/Parsers/Sample/ASimAuthenticationAWSCloudTrail.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "workspace": {

--- a/Parsers/Sample/ASimDnsMicrosoftOMS.json
+++ b/Parsers/Sample/ASimDnsMicrosoftOMS.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "workspace": {

--- a/Parsers/Sample/FileEventMicrosoftSysmonFileCreated.json
+++ b/Parsers/Sample/FileEventMicrosoftSysmonFileCreated.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "workspace": {

--- a/Parsers/Sample/NetworkSessionCheckPoint.json
+++ b/Parsers/Sample/NetworkSessionCheckPoint.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "workspace": {

--- a/Parsers/Sample/ProcessEventMicrosoftSysmonTerminate.json
+++ b/Parsers/Sample/ProcessEventMicrosoftSysmonTerminate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "workspace": {


### PR DESCRIPTION
Previously, attempting to convert some ARM templates to Bicep with the 'az bicep decompile' command was failing due to incorrect properties. This PR addresses these errors.